### PR TITLE
Fix missing UID and UID

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN wget https://github.com/srrDB/pyrescene/archive/refs/heads/master.zip \
 ENV UID=1000
 ENV GID=1000
 
-RUN addgroup -S appgroup && adduser -S app -G appgroup
+RUN addgroup -S appgroup -g "$GID" && adduser -S app -G appgroup -u "$UID"
 
 RUN mkdir -p /scan /srr
 WORKDIR /scan/


### PR DESCRIPTION
If you don't use the variables then you get:
```
$ whoami
app
```
```
$ id
uid=100(app) gid=101(appgroup) groups=101(appgroup)
```

After my edits, you get instead:
```
$ whoami
app
```
```
$ id
uid=1000(app) gid=1000(appgroup) groups=1000(appgroup)
```
This actually better matches what Gfy is doing upstream.
